### PR TITLE
Make spyOnProperty available in tests

### DIFF
--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -281,6 +281,10 @@ getJasmineRequireObj().Env = function(j$) {
       return spyRegistry.spyOn.apply(spyRegistry, arguments);
     };
 
+    this.spyOnProperty = function() {
+      return spyRegistry.spyOnProperty.apply(spyRegistry, arguments);
+    };
+
     var suiteFactory = function(description) {
       var suite = new j$.Suite({
         env: self,

--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -56,6 +56,10 @@ getJasmineRequireObj().interface = function(jasmine, env) {
       return env.spyOn(obj, methodName);
     },
 
+    spyOnProperty: function(obj, methodName, accessType) {
+      return env.spyOnProperty(obj, methodName, accessType);
+    },
+
     jsApiReporter: new jasmine.JsApiReporter({
       timer: new jasmine.Timer()
     }),


### PR DESCRIPTION
Needed adding to the env and require interface

I did this manually to the `lib/` files to get `spyOnProperty` working in my specs, so thought I should commit to the source and get into your PR https://github.com/jasmine/jasmine/pull/1008 so it can be merged
